### PR TITLE
Fix random index out of bounds

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ nouns = require('./nouns')
 
 module.exports = function() {
   id = shortid.generate()
-  adjectiveIndex = Math.round(Math.random() * adjectives.length)
-  nounIndex = Math.round(Math.random() * nouns.length)
+  adjectiveIndex = Math.floor(Math.random() * adjectives.length)
+  nounIndex = Math.floor(Math.random() * nouns.length)
   return adjectives[adjectiveIndex] + "-" + nouns[nounIndex] + "-" + id
 }


### PR DESCRIPTION
`Math.round(Math.random() * n)` returns numbers in the range of `0, 1, 2 ... n-1, n`, which means the array index can get out of bounds when `n = array.length`. This doesn't throw any errors, but results in names sometimes being generated like `red-undefined-4JRPVu_t`.

Using `Math.floor` fixes this problem.