### PR TITLE
Replace shortid to nanoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,18 @@ rid()
 Here is, literally, the entire source code:
 
 ```js
-shortid = require('shortid')
+nanoid = require('nanoid')
 adjectives = require('./adjectives')
 nouns = require('./nouns')
 
 // adjectives and nouns from https://gist.github.com/afriggeri/1266756
 
 module.exports = function() {
-  id = shortid.generate()
+  id = nanoid(7)
   adjectiveIndex = Math.round(Math.random() * adjectives.length)
   nounIndex = Math.round(Math.random() * nouns.length)
   return adjectives[adjectiveIndex] + "-" + nouns[nounIndex] + "-" + id
 }
 ```
 
-The `shortid` package lends uniqueness and collision resistance, and the adjectives and nouns the human readability.
+The `nanoid` package lends uniqueness and collision resistance, and the adjectives and nouns the human readability.

--- a/index.js
+++ b/index.js
@@ -1,12 +1,12 @@
-shortid = require('shortid')
-adjectives = require('./adjectives')
-nouns = require('./nouns')
+var nanoid = require('nanoid')
+var adjectives = require('./adjectives')
+var nouns = require('./nouns')
 
 // adjectives and nouns from https://gist.github.com/afriggeri/1266756
 
 module.exports = function() {
-  id = shortid.generate()
-  adjectiveIndex = Math.floor(Math.random() * adjectives.length)
-  nounIndex = Math.floor(Math.random() * nouns.length)
+  var id = nanoid(7)
+  var adjectiveIndex = Math.floor(Math.random() * adjectives.length)
+  var nounIndex = Math.floor(Math.random() * nouns.length)
   return adjectives[adjectiveIndex] + "-" + nouns[nounIndex] + "-" + id
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,6 @@
   "author": "Dave Wasmer",
   "license": "MIT",
   "dependencies": {
-    "shortid": "^2.1.3"
+    "nanoid": "^1.0.1"
   }
 }


### PR DESCRIPTION
Hi. Thanks for an awesome project. I found the way how to make it a little better. By replacing unqiue ID generator from `shortid` to [`nanoid`](https://github.com/ai/nanoid).

1. `shortid` is not maintained anymore (and issue tracker has many [important issues](https://github.com/dylang/shortid/issues)). I tried to took maintenance, but found that I can’t fix `shortid` with keeping API.
2. `shortid` has problem with random generator ([issue](https://github.com/dylang/shortid/issues/70)) and ID uniformity ([issue](https://github.com/dylang/shortid/issues/85)). `nanoid` use hardware random generator and has special uniformity tests ([docs](https://github.com/ai/nanoid#security)).
3. `nanoid` is just [179 bytes](https://github.com/ai/nanoid/blob/master/package.json#L64-L67). `shortid` is 2 times bigger (about 0.5 KB).
4. `nanoid` is [10x times faster](https://github.com/ai/nanoid#benchmark) than `shortid`.

@davewasmer I kept old ID size, everything will be the same for the user.